### PR TITLE
AWS Provider 5.0 upgrade

### DIFF
--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -1,5 +1,5 @@
 module "ec2_test_instance" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance"
+  source = "../../"
 
   providers = {
     aws.core-vpc = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/test/unit-test/versions.tf
+++ b/test/unit-test/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version               = "~> 4.9"
+      version               = "~> 5.0"
       source                = "hashicorp/aws"
       configuration_aliases = [aws.core-vpc]
     }


### PR DESCRIPTION
Bumps version constraint to ~> 5.0.
Set `unit-test` to use relative local reference
Related to https://github.com/ministryofjustice/modernisation-platform/issues/4173