### PR TITLE
swap out depracated value after aws provider now ~> 5.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -98,8 +98,8 @@ resource "aws_instance" "this" {
 
 resource "aws_eip" "this" {
   #checkov:skip=CKV2_AWS_19: "EIP attachment is handled through separate resource"
-  count = var.instance.associate_public_ip_address ? 1 : 0
-  vpc   = true
+  count  = var.instance.associate_public_ip_address ? 1 : 0
+  domain = "vpc"
   tags = merge(local.tags, {
     Name = var.name
   })


### PR DESCRIPTION
aws_eip resource parameters changed as per https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip in version 5.6.2 (version 5+ really) to address warning in plan output [here](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/5446697187/jobs/9907804431?pr=2722)

```
│ Warning: Argument is deprecated
│ 
│   with module.baseline.module.ec2_instance.aws_eip.this,
│   on .terraform/modules/baseline.ec2_instance/main.tf line 102, in resource "aws_eip" "this":
│  102:   vpc   = true
│ 
│ use domain attribute instead
```