### PR TITLE
DSOS-1987: allow specific tags for ec2 and ebs resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "aws_instance" "this" {
     volume_size           = local.ebs_volume_root.size
     volume_type           = local.ebs_volume_root.type
 
-    tags = merge(local.tags, {
+    tags = merge(local.tags, var.ebs_volume_tags, {
       Name = join("-", [var.name, "root", data.aws_ami.this.root_device_name])
     })
   }
@@ -61,7 +61,7 @@ resource "aws_instance" "this" {
       volume_size = ebs_block_device.value.size
       volume_type = ebs_block_device.value.type
 
-      tags = merge(local.tags, {
+      tags = merge(local.tags, var.ebs_volume_tags, {
         Name = try(
           join("-", [var.name, ebs_block_device.value.label, ebs_block_device.key]),
           join("-", [var.name, ebs_block_device.key])
@@ -87,7 +87,7 @@ resource "aws_instance" "this" {
     ]
   }
 
-  tags = merge(local.tags, {
+  tags = merge(local.tags, var.instance.tags, {
     Name = var.name
   })
 }
@@ -131,15 +131,12 @@ resource "aws_ebs_volume" "this" {
   # you may run into a permission issue if the AMI is not in self account
   snapshot_id = lookup(each.value, "snapshot_id", null)
 
-  tags = merge(
-    local.tags,
-    {
-      Name = try(
-        join("-", [var.name, each.value.label, each.key]),
-        join("-", [var.name, each.key])
-      )
-    }
-  )
+  tags = merge(local.tags, var.ebs_volume_tags, {
+    Name = try(
+      join("-", [var.name, each.value.label, each.key]),
+      join("-", [var.name, each.key])
+    )
+  })
 
   lifecycle {
     ignore_changes = [snapshot_id] # retain data if AMI is updated. If you want to start from fresh, destroy it

--- a/main.tf
+++ b/main.tf
@@ -189,6 +189,10 @@ resource "random_password" "this" {
 }
 
 resource "aws_ssm_parameter" "this" {
+  #checkov:skip=CKV_AWS_337: Ensure SSM parameters are using KMS CMK
+  # An AWS managed key is used at the moment.
+  # Fix ticket https://dsdmoj.atlassian.net/browse/DSOS-2011
+
   for_each = var.ssm_parameters != null ? var.ssm_parameters : {}
 
   name        = "/${var.ssm_parameters_prefix}${var.name}/${each.key}"

--- a/test/unit-test/data.tf
+++ b/test/unit-test/data.tf
@@ -21,6 +21,7 @@ data "aws_iam_policy_document" "ec2_test_policy" {
     #checkov:skip=CKV_AWS_109:
     #checkov:skip=CKV_AWS_111:
     #checkov:skip=CKV_AWS_107:
+    #checkov:skip=CKV_AWS_356:
 
     sid    = "CustomEc2Policy"
     effect = "Allow"

--- a/test/unit-test/data.tf
+++ b/test/unit-test/data.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "ec2_test_policy" {
     #checkov:skip=CKV_AWS_109:
     #checkov:skip=CKV_AWS_111:
     #checkov:skip=CKV_AWS_107:
-    #checkov:skip=CKV_AWS_356:
+    #checkov:skip=CKV_AWS_356: Skipping, as the policy is used within the unit-test only.
 
     sid    = "CustomEc2Policy"
     effect = "Allow"

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "subnet_id" {
 
 variable "tags" {
   type        = map(any)
-  description = "Default tags to be applied to resources.  Additional tags can be added to EBS volumes or EC2s, see instance.tag and ebs_volume_tags variables."
+  description = "Default tags to be applied to resources.  Additional tags can be added to EBS volumes or EC2s, see instance.tags and ebs_volume_tags variables."
 }
 
 variable "account_ids_lookup" {

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "subnet_id" {
 
 variable "tags" {
   type        = map(any)
-  description = "Default tags to be applied to resources.  Additional tags can be added to EBS volumes or EC2s, see instance and ebs_volume_tags variables."
+  description = "Default tags to be applied to resources.  Additional tags can be added to EBS volumes or EC2s, see instance.tag and ebs_volume_tags variables."
 }
 
 variable "account_ids_lookup" {

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "subnet_id" {
 
 variable "tags" {
   type        = map(any)
-  description = "Default tags to be applied to resources"
+  description = "Default tags to be applied to resources.  Additional tags can be added to EBS volumes or EC2s, see instance and ebs_volume_tags variables."
 }
 
 variable "account_ids_lookup" {
@@ -84,6 +84,7 @@ variable "instance" {
       enable_resource_name_dns_a_record    = optional(bool)
       hostname_type                        = string
     }))
+    tags = optional(map(string), {})
   })
 }
 
@@ -141,6 +142,12 @@ variable "ebs_volumes" {
     type        = optional(string)
     kms_key_id  = optional(string)
   }))
+}
+
+variable "ebs_volume_tags" {
+  description = "Additional tags to apply to ebs volumes"
+  type        = map(string)
+  default     = {}
 }
 
 variable "route53_records" {


### PR DESCRIPTION
Finer control over tagging.  Allow additional tags specific to ec2_instance and ebs_volume resources.   This allows us to add a backup tag to only the ec2_instance resource, thus avoiding duplicate ec2 and ebs backups.  Tested in nomis accounts. 