### PR TITLE
DSOS-2124: allow placeholder ssm parameters

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -22,13 +22,13 @@ locals {
     }) if value.value == null && value.random != null
   }
   ssm_parameters_file = {
-    for item in var.ssm_parameters :
+    for key, value in var.ssm_parameters :
     key => merge(value, {
       value = file(value.file)
     }) if value.value == null && value.random == null && value.file != null
   }
   ssm_parameters_default = {
-    for item in local.ssm_parameters :
+    for key, value in local.ssm_parameters :
     key => merge(value, {
       value = "placeholder, overwrite me outside of terraform"
     }) if value.value == null && value.random == null && value.file == null

--- a/locals.tf
+++ b/locals.tf
@@ -113,7 +113,7 @@ locals {
 
   user_data_args_ssm_params = {
     for key, value in var.ssm_parameters != null ? var.ssm_parameters : {} :
-    "ssm_parameter_${key}" => aws_ssm_parameter.this[key].name
+    "ssm_parameter_${key}" => try(aws_ssm_parameter.this[key].name, aws_ssm_parameter.placeholder[key].name)
   }
 
   user_data_args_common = {

--- a/locals.tf
+++ b/locals.tf
@@ -21,17 +21,11 @@ locals {
       value = random_password.this[key].result
     }) if value.value == null && value.random != null
   }
-  ssm_parameters_file = {
-    for key, value in var.ssm_parameters :
-    key => merge(value, {
-      value = file(value.file)
-    }) if value.value == null && value.random == null && value.file != null
-  }
   ssm_parameters_default = {
     for key, value in var.ssm_parameters :
     key => merge(value, {
       value = "placeholder, overwrite me outside of terraform"
-    }) if value.value == null && value.random == null && value.file == null
+    }) if value.value == null && value.random == null
   }
 
   ami_block_device_mappings = {

--- a/locals.tf
+++ b/locals.tf
@@ -8,21 +8,21 @@ locals {
   tags = merge(local.default_tags, local.ssm_parameters_prefix_tag, var.tags)
 
   ssm_random_passwords = {
-    for key, value in var.ssm_parameters != null ? var.ssm_parameters :
+    for key, value in var.ssm_parameters != null ? var.ssm_parameters : {} :
     key => value.random if value.random != null
   }
   ssm_parameters_value = {
-    for key, value in var.ssm_parameters != null ? var.ssm_parameters :
+    for key, value in var.ssm_parameters != null ? var.ssm_parameters : {} :
     key => value if value.value != null
   }
   ssm_parameters_random = {
-    for key, value in var.ssm_parameters != null ? var.ssm_parameters :
+    for key, value in var.ssm_parameters != null ? var.ssm_parameters : {} :
     key => merge(value, {
       value = random_password.this[key].result
     }) if value.value == null && value.random != null
   }
   ssm_parameters_default = {
-    for key, value in var.ssm_parameters != null ? var.ssm_parameters :
+    for key, value in var.ssm_parameters != null ? var.ssm_parameters : {} :
     key => merge(value, {
       value = "placeholder, overwrite me outside of terraform"
     }) if value.value == null && value.random == null

--- a/locals.tf
+++ b/locals.tf
@@ -16,13 +16,13 @@ locals {
     key => value if value.value != null
   }
   ssm_parameters_random = {
-    for key, value in var.ssm_parameterss :
+    for key, value in var.ssm_parameters :
     key => merge(value, {
       value = random_password.this[key].result
     }) if value.value == null && value.random != null
   }
   ssm_parameters_file = {
-    for item in var.ssm_parameterss :
+    for item in var.ssm_parameters :
     key => merge(value, {
       value = file(value.file)
     }) if value.value == null && value.random == null && value.file != null

--- a/locals.tf
+++ b/locals.tf
@@ -8,21 +8,21 @@ locals {
   tags = merge(local.default_tags, local.ssm_parameters_prefix_tag, var.tags)
 
   ssm_random_passwords = {
-    for key, value in var.ssm_parameters :
+    for key, value in var.ssm_parameters != null ? var.ssm_parameters :
     key => value.random if value.random != null
   }
   ssm_parameters_value = {
-    for key, value in var.ssm_parameters :
+    for key, value in var.ssm_parameters != null ? var.ssm_parameters :
     key => value if value.value != null
   }
   ssm_parameters_random = {
-    for key, value in var.ssm_parameters :
+    for key, value in var.ssm_parameters != null ? var.ssm_parameters :
     key => merge(value, {
       value = random_password.this[key].result
     }) if value.value == null && value.random != null
   }
   ssm_parameters_default = {
-    for key, value in var.ssm_parameters :
+    for key, value in var.ssm_parameters != null ? var.ssm_parameters :
     key => merge(value, {
       value = "placeholder, overwrite me outside of terraform"
     }) if value.value == null && value.random == null

--- a/locals.tf
+++ b/locals.tf
@@ -28,7 +28,7 @@ locals {
     }) if value.value == null && value.random == null && value.file != null
   }
   ssm_parameters_default = {
-    for key, value in local.ssm_parameters :
+    for key, value in var.ssm_parameters :
     key => merge(value, {
       value = "placeholder, overwrite me outside of terraform"
     }) if value.value == null && value.random == null && value.file == null

--- a/locals.tf
+++ b/locals.tf
@@ -7,6 +7,33 @@ locals {
   }
   tags = merge(local.default_tags, local.ssm_parameters_prefix_tag, var.tags)
 
+  ssm_random_passwords = {
+    for key, value in var.ssm_parameters :
+    key => value.random if value.random != null
+  }
+  ssm_parameters_value = {
+    for key, value in var.ssm_parameters :
+    key => value if value.value != null
+  }
+  ssm_parameters_random = {
+    for key, value in var.ssm_parameterss :
+    key => merge(value, {
+      value = random_password.this[key].result
+    }) if value.value == null && value.random != null
+  }
+  ssm_parameters_file = {
+    for item in var.ssm_parameterss :
+    key => merge(value, {
+      value = file(value.file)
+    }) if value.value == null && value.random == null && value.file != null
+  }
+  ssm_parameters_default = {
+    for item in local.ssm_parameters :
+    key => merge(value, {
+      value = "placeholder, overwrite me outside of terraform"
+    }) if value.value == null && value.random == null && value.file == null
+  }
+
   ami_block_device_mappings = {
     for bdm in data.aws_ami.this.block_device_mappings : bdm.device_name => bdm
   }

--- a/main.tf
+++ b/main.tf
@@ -193,7 +193,6 @@ resource "aws_ssm_parameter" "this" {
   for_each = merge(
     local.ssm_parameters_value,
     local.ssm_parameters_random,
-    local.ssm_parameters_file
   )
 
   name        = "/${var.ssm_parameters_prefix}${var.name}/${each.key}"

--- a/main.tf
+++ b/main.tf
@@ -190,7 +190,7 @@ resource "random_password" "this" {
 
 # SSM parameters with values managed by terraform
 resource "aws_ssm_parameter" "this" {
-  #checkov:skip=CKV_AWS_337: Ensure SSM parameters are using KMS CMK. Up to the user of module to set this appropriately.
+  #checkov:skip=CKV2_AWS_34: AWS SSM Parameter should be Encrypted. SecureString is the default but can be changed by user if needed
 
   for_each = merge(
     local.ssm_parameters_value,
@@ -210,7 +210,7 @@ resource "aws_ssm_parameter" "this" {
 
 # Placeholder SSM parameters with values set elsewhere
 resource "aws_ssm_parameter" "placeholder" {
-  #checkov:skip=CKV_AWS_337: Ensure SSM parameters are using KMS CMK. Up to the user of module to set this appropriately.
+  #checkov:skip=CKV2_AWS_34: AWS SSM Parameter should be Encrypted. SecureString is the default but can be changed by user if needed
 
   for_each = local.ssm_parameters_default
 

--- a/main.tf
+++ b/main.tf
@@ -276,11 +276,10 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy" "ssm_parameter" {
-  count       = var.ssm_parameters != null ? 1 : 0
-  name        = "Ec2SSMParameterPolicy-${var.name}"
-  description = "Allows access to ${var.name} EC2 SSM parameters"
-  role        = aws_iam_role.this.id
-  policy      = data.aws_iam_policy_document.ssm_parameter.json
+  count  = var.ssm_parameters != null ? 1 : 0
+  name   = "Ec2SSMParameterPolicy-${var.name}"
+  role   = aws_iam_role.this.id
+  policy = data.aws_iam_policy_document.ssm_parameter.json
 }
 
 resource "aws_iam_instance_profile" "this" {

--- a/main.tf
+++ b/main.tf
@@ -233,7 +233,7 @@ resource "aws_ssm_parameter" "placeholder" {
 # provisioning process such as ansible)
 #------------------------------------------------------------------------------
 
-data "aws_iam_policy_document" "asm_parameter" {
+data "aws_iam_policy_document" "ssm_parameter" {
   statement {
     effect = "Allow"
     actions = flatten([
@@ -275,11 +275,12 @@ resource "aws_iam_role" "this" {
   )
 }
 
-resource "aws_iam_role_policy" "asm_parameter" {
-  count  = var.ssm_parameters != null ? 1 : 0
-  name   = "asm-parameter-access-${var.name}"
-  role   = aws_iam_role.this.id
-  policy = data.aws_iam_policy_document.asm_parameter.json
+resource "aws_iam_role_policy" "ssm_parameter" {
+  count       = var.ssm_parameters != null ? 1 : 0
+  name        = "Ec2SSMParameterPolicy-${var.name}"
+  description = "Allows access to ${var.name} EC2 SSM parameters"
+  role        = aws_iam_role.this.id
+  policy      = data.aws_iam_policy_document.ssm_parameter.json
 }
 
 resource "aws_iam_instance_profile" "this" {

--- a/main.tf
+++ b/main.tf
@@ -190,6 +190,8 @@ resource "random_password" "this" {
 
 # SSM parameters with values managed by terraform
 resource "aws_ssm_parameter" "this" {
+  #checkov:skip=CKV_AWS_337: Ensure SSM parameters are using KMS CMK. Up to the user of module to set this appropriately.
+
   for_each = merge(
     local.ssm_parameters_value,
     local.ssm_parameters_random,
@@ -208,6 +210,8 @@ resource "aws_ssm_parameter" "this" {
 
 # Placeholder SSM parameters with values set elsewhere
 resource "aws_ssm_parameter" "placeholder" {
+  #checkov:skip=CKV_AWS_337: Ensure SSM parameters are using KMS CMK. Up to the user of module to set this appropriately.
+
   for_each = local.ssm_parameters_default
 
   name        = "/${var.ssm_parameters_prefix}${var.name}/${each.key}"

--- a/variables.tf
+++ b/variables.tf
@@ -176,12 +176,11 @@ variable "ssm_parameters_prefix" {
 }
 
 variable "ssm_parameters" {
-  description = "A map of SSM parameters to create.  If parameters are manually created, set to {} so IAM role still created"
+  description = "A map of SSM parameters to create. Set a specific value or a randomly generated value.  If neither random or value are set, a placeholder value is created which can be updated outside of terraform"
   type = map(object({
     description = optional(string)
     type        = optional(string, "SecureString")
     kms_key_id  = optional(string)
-    file        = optional(string)
     random = optional(object({
       length  = number
       special = optional(bool)

--- a/variables.tf
+++ b/variables.tf
@@ -178,11 +178,15 @@ variable "ssm_parameters_prefix" {
 variable "ssm_parameters" {
   description = "A map of SSM parameters to create.  If parameters are manually created, set to {} so IAM role still created"
   type = map(object({
-    random = object({
+    description = optional(string)
+    type        = optional(string, "SecureString")
+    kms_key_id  = optional(string)
+    file        = optional(string)
+    random = optional(object({
       length  = number
-      special = bool
-    })
-    description = string
+      special = optional(bool)
+    }))
+    value = optional(string)
   }))
   default = null
 }


### PR DESCRIPTION
See https://dsdmoj.atlassian.net/browse/DSOS-2124

Following discussions with DBAs, they want the ability to rotate passwords (stored in SSM param) outside of terraform. To achieve this, we need to add a lifecycle rule to ignore SSM parameter value changes.  Also tidied up some naming as part of this PR:
- renamed "ASM" variables to "SSM" (ASM is the name of the DB secret this feature was originally for, but we should have renamed to SSM when we created the module)
- added "kms_key_id" parameter to allow optional setting of KMS (fixes checkov warning)
- added "value" parameter to allow setting the value to a fixed string rather than a random string
- if neither value or random is set, a placeholder value with lifecycle rule is created.
- If a placeholder value is created, we also add "PutParameter" to the IAM policy to allow the EC2 to update it.

I've tested this in nomis accounts with all variants of options and with and without using KMS Key ID.  All works fine + is backward compatible with previous version.  Module is mainly used by DSO, and some use by Probation WebOps.