### PR TITLE
Introducing new outputs and test outputs and randomising resource names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ env/
 .vscode
 *.code-workspace
 *.sha256
+.terraform*
 terraform.tfstate
 terraform.tfstate.backup

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "aws_instance" {
   description = "aws_instance resource"
   value       = aws_instance.this
 }
+
+output "aws_ebs_volume" {
+  description = "aws_ebs_volume resource"
+  value       = aws_ebs_volume.this
+}

--- a/test/unit-test/locals.tf
+++ b/test/unit-test/locals.tf
@@ -31,6 +31,7 @@ locals {
   ec2_test = {
     tags = {
       component = "test"
+      backup = true
     }
 
     instance = {
@@ -81,9 +82,15 @@ locals {
           os-type     = "Linux"
           component   = "ndh"
           environment = "test"
+          backup = true
         }
+        ebs_block_device_inline = true
         ebs_volumes = {
-          "/dev/sda1" = { kms_key_id = data.aws_kms_key.default_ebs.arn }
+          "/dev/sda1" = { kms_key_id = data.aws_kms_key.default_ebs.arn, size = 30}
+          "/dev/sdb"  = { kms_key_id = data.aws_kms_key.default_ebs.arn, size = 100 }
+        }
+        ebs_volume_tags = {
+          backup = false
         }
         ami_name  = "RHEL-7.9_HVM-*"
         ami_owner = "309956199498"
@@ -96,9 +103,16 @@ locals {
           os-type     = "Linux"
           component   = "ndh"
           environment = "test"
+          backup = false
         }
+        ebs_block_device_inline = false
         ebs_volumes = {
           "/dev/sda1" = { kms_key_id = data.aws_kms_key.default_ebs.arn }
+          "/dev/sdb"  = { kms_key_id = data.aws_kms_key.default_ebs.arn, size = 100 }
+
+        }
+        ebs_volume_tags = {
+          backup = true
         }
         ami_name  = "RHEL-7.9_HVM-*"
         ami_owner = "309956199498"
@@ -125,7 +139,7 @@ locals {
 
 # create single managed policy
 resource "aws_iam_policy" "ec2_test_common_policy" {
-  name        = "ec2-test-common-policy"
+  name        = "ec2-test-common-policy${random_id.test_id.hex}"
   path        = "/"
   description = "Common policy for all ec2 instances"
   policy      = data.aws_iam_policy_document.ec2_test_common_combined.json
@@ -139,7 +153,7 @@ resource "aws_iam_policy" "ec2_test_common_policy" {
 
 # Keypair for ec2-terratest-user
 resource "aws_key_pair" "ec2-terratest-user" {
-  key_name   = "ec2-terratest-user"
+  key_name   = "ec2-terratest-user${random_id.test_id.hex}"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
   tags = merge(
     local.tags,

--- a/test/unit-test/locals.tf
+++ b/test/unit-test/locals.tf
@@ -31,7 +31,7 @@ locals {
   ec2_test = {
     tags = {
       component = "test"
-      backup = true
+      backup    = true
     }
 
     instance = {
@@ -82,11 +82,11 @@ locals {
           os-type     = "Linux"
           component   = "ndh"
           environment = "test"
-          backup = true
+          backup      = true
         }
         ebs_block_device_inline = true
         ebs_volumes = {
-          "/dev/sda1" = { kms_key_id = data.aws_kms_key.default_ebs.arn, size = 30}
+          "/dev/sda1" = { kms_key_id = data.aws_kms_key.default_ebs.arn, size = 30 }
           "/dev/sdb"  = { kms_key_id = data.aws_kms_key.default_ebs.arn, size = 100 }
         }
         ebs_volume_tags = {
@@ -103,7 +103,7 @@ locals {
           os-type     = "Linux"
           component   = "ndh"
           environment = "test"
-          backup = false
+          backup      = false
         }
         ebs_block_device_inline = false
         ebs_volumes = {

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -1,3 +1,7 @@
+resource "random_id" "test_id" {
+  byte_length = 4
+}
+
 module "ec2_test_instance" {
   source = "../../"
 
@@ -7,7 +11,7 @@ module "ec2_test_instance" {
 
   for_each = try(local.ec2_test.ec2_test_instances, {})
 
-  name = each.key
+  name = "${each.key}${random_id.test_id.hex}"
 
   ami_name                      = each.value.ami_name
   ami_owner                     = try(each.value.ami_owner, "core-shared-services-production")
@@ -15,11 +19,12 @@ module "ec2_test_instance" {
   ebs_volumes_copy_all_from_ami = try(each.value.ebs_volumes_copy_all_from_ami, true)
   ebs_volume_config             = lookup(each.value, "ebs_volume_config", {})
   ebs_volumes                   = lookup(each.value, "ebs_volumes", {})
+  ebs_volume_tags               = lookup(each.value, "ebs_volume_tags", {})
   ssm_parameters_prefix         = lookup(each.value, "ssm_parameters_prefix", "test/")
   ssm_parameters                = lookup(each.value, "ssm_parameters", null)
   route53_records               = merge(local.ec2_test.route53_records, lookup(each.value, "route53_records", {}))
 
-  iam_resource_names_prefix = "ec2-test-instance"
+  iam_resource_names_prefix = "ec2-test-instance${random_id.test_id.hex}"
   instance_profile_policies = local.ec2_common_managed_policies
 
   business_unit            = local.business_unit

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -26,3 +26,58 @@ output "subnet-arn" {
   description = "Subnet ARN"
   value       = try(data.aws_subnet.private_subnets_a.arn, "")
 }
+
+output "backup-tag-input" {
+  description = "backup tag set through var.tags input"
+  value       = local.ec2_test.tags.backup
+}
+
+output "backup-instance-1-tag-input" {
+  description = "backup tag set through var.instance.tags input"
+  value       = local.ec2_test.ec2_test_instances.example-test-instance-1.tags.backup
+}
+
+output "ebs_block_device_inline-instance-1-input" {
+  description = "var.instance.ebs_block_device_inline input"
+  value       = local.ec2_test.ec2_test_instances.example-test-instance-1.ebs_block_device_inline
+}
+
+output "backup-instance-1-ebs-volume-tag-input" {
+  description = "backup tag set through var.ebs_volume_tags input"
+  value       = local.ec2_test.ec2_test_instances.example-test-instance-1.ebs_volume_tags.backup
+}
+
+output "backup-instance-2-tag-input" {
+  description = "backup tag set through var.instance.tags input"
+  value       = local.ec2_test.ec2_test_instances.example-test-instance-2.tags.backup
+}
+
+output "ebs_block_device_inline-instance-2-input" {
+  description = "var.instance.ebs_block_device_inline input"
+  value       = local.ec2_test.ec2_test_instances.example-test-instance-2.ebs_block_device_inline
+}
+
+output "backup-instance-2-ebs-volume-tag-input" {
+  description = "backup tag set through var.ebs_volume_tags input"
+  value       = local.ec2_test.ec2_test_instances.example-test-instance-2.ebs_volume_tags.backup
+}
+
+output "applied-instance-backup-tag" {
+  description = "backup tag applied on the instance"
+  value       = [ for instance in module.ec2_test_instance : instance.aws_instance.tags.backup ]
+}
+
+output "applied-backup-root-inline-tag" {
+  description = "backup tag applied inline on the instance root block device"
+  value       = [ for instance in module.ec2_test_instance : instance.aws_instance.root_block_device[0].tags.backup ]
+}
+
+output "applied-backup-ebs-inline-tag" {
+  description = "backup tag applied inline on the instance ebs block device"
+  value       = [ for instance in module.ec2_test_instance : [ for ebs_block in instance.aws_instance.ebs_block_device : ebs_block.tags.backup ] ]
+}
+
+output "applied-backup-ebs-tag" {
+  description = "backup tag applied on the ebs_volume"
+  value       = [ for instance in module.ec2_test_instance : [for ebs_device in instance.aws_ebs_volume : ebs_device.tags.backup] ]
+}

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -64,20 +64,20 @@ output "backup-instance-2-ebs-volume-tag-input" {
 
 output "applied-instance-backup-tag" {
   description = "backup tag applied on the instance"
-  value       = [ for instance in module.ec2_test_instance : instance.aws_instance.tags.backup ]
+  value       = [for instance in module.ec2_test_instance : instance.aws_instance.tags.backup]
 }
 
 output "applied-backup-root-inline-tag" {
   description = "backup tag applied inline on the instance root block device"
-  value       = [ for instance in module.ec2_test_instance : instance.aws_instance.root_block_device[0].tags.backup ]
+  value       = [for instance in module.ec2_test_instance : instance.aws_instance.root_block_device[0].tags.backup]
 }
 
 output "applied-backup-ebs-inline-tag" {
   description = "backup tag applied inline on the instance ebs block device"
-  value       = [ for instance in module.ec2_test_instance : [ for ebs_block in instance.aws_instance.ebs_block_device : ebs_block.tags.backup ] ]
+  value       = [for instance in module.ec2_test_instance : [for ebs_block in instance.aws_instance.ebs_block_device : ebs_block.tags.backup]]
 }
 
 output "applied-backup-ebs-tag" {
   description = "backup tag applied on the ebs_volume"
-  value       = [ for instance in module.ec2_test_instance : [for ebs_device in instance.aws_ebs_volume : ebs_device.tags.backup] ]
+  value       = [for instance in module.ec2_test_instance : [for ebs_device in instance.aws_ebs_volume : ebs_device.tags.backup]]
 }

--- a/test/unit-test/security-groups.tf
+++ b/test/unit-test/security-groups.tf
@@ -3,7 +3,7 @@ resource "aws_security_group" "test" {
   #checkov:skip=CKV_AWS_25:
   #checkov:skip=CKV_AWS_24:
   #checkov:skip=CKV_AWS_260:
-  name        = "Terratest-SG"
+  name        = "Terratest-SG${random_id.test_id.hex}"
   description = "Test SG for Terratest"
   vpc_id      = data.aws_vpc.shared.id
   ingress {
@@ -13,8 +13,6 @@ resource "aws_security_group" "test" {
     cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
     description      = "Test SG for Terratest"
-
-
   }
 
   egress {


### PR DESCRIPTION
This PR is to do with the https://github.com/ministryofjustice/modernisation-platform/issues/4803 issue.

This issue is already implemented, but this PR is to improve the terratests that are in place.
This change is to introduce new outputs in the module and to use them later on in the terratests. This change is also adding random values to resources names in the terratests to allow smooth standing up and tearing down of the test environments.
This has been tested locally.