### PR TITLE
DSOS-2406: align secretsmanager options with ssm

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -28,6 +28,27 @@ locals {
     }) if value.value == null && value.random == null
   }
 
+  secretsmanager_random_passwords = {
+    for key, value in var.secretsmanager_secrets != null ? var.secretsmanager_secrets : {} :
+    key => value.random if value.random != null
+  }
+  secretsmanager_secrets_value = {
+    for key, value in var.secretsmanager_secrets != null ? var.secretsmanager_secrets : {} :
+    key => value if value.value != null
+  }
+  secretsmanager_secrets_random = {
+    for key, value in var.secretsmanager_secrets != null ? var.secretsmanager_secrets : {} :
+    key => merge(value, {
+      value = random_password.secrets[key].result
+    }) if value.value == null && value.random != null
+  }
+  secretsmanager_secrets_default = {
+    for key, value in var.ssecretsmanager_secret != null ? var.secretsmanager_secrets : {} :
+    key => merge(value, {
+      value = "placeholder, overwrite me outside of terraform"
+    }) if value.value == null && value.random == null
+  }
+
   ami_block_device_mappings = {
     for bdm in data.aws_ami.this.block_device_mappings : bdm.device_name => bdm
   }

--- a/locals.tf
+++ b/locals.tf
@@ -44,9 +44,7 @@ locals {
   }
   secretsmanager_secrets_default = {
     for key, value in var.secretsmanager_secrets != null ? var.secretsmanager_secrets : {} :
-    key => merge(value, {
-      value = "placeholder, overwrite me outside of terraform"
-    }) if value.value == null && value.random == null
+    key => value if value.value == null && value.random == null
   }
 
   ami_block_device_mappings = {

--- a/locals.tf
+++ b/locals.tf
@@ -43,7 +43,7 @@ locals {
     }) if value.value == null && value.random != null
   }
   secretsmanager_secrets_default = {
-    for key, value in var.ssecretsmanager_secret != null ? var.secretsmanager_secrets : {} :
+    for key, value in var.secretsmanager_secret != null ? var.secretsmanager_secrets : {} :
     key => merge(value, {
       value = "placeholder, overwrite me outside of terraform"
     }) if value.value == null && value.random == null

--- a/locals.tf
+++ b/locals.tf
@@ -43,7 +43,7 @@ locals {
     }) if value.value == null && value.random != null
   }
   secretsmanager_secrets_default = {
-    for key, value in var.secretsmanager_secret != null ? var.secretsmanager_secrets : {} :
+    for key, value in var.secretsmanager_secrets != null ? var.secretsmanager_secrets : {} :
     key => merge(value, {
       value = "placeholder, overwrite me outside of terraform"
     }) if value.value == null && value.random == null

--- a/main.tf
+++ b/main.tf
@@ -251,7 +251,7 @@ resource "aws_secretsmanager_secret" "fixed" {
 
   name                    = "/${var.secretsmanager_secrets_prefix}${var.name}/${each.key}"
   description             = each.value.description
-  kms_key_id              = each.value.kms_key_id != null ? try(var.environment.kms_keys[each.value.kms_key_id].arn, each.value.kms_key_id) : null
+  kms_key_id              = each.value.kms_key_id
   recovery_window_in_days = each.value.recovery_window_in_days
 
   tags = merge(local.tags, {
@@ -266,7 +266,7 @@ resource "aws_secretsmanager_secret" "placeholder" {
 
   name                    = "/${var.secretsmanager_secrets_prefix}${var.name}/${each.key}"
   description             = each.value.description
-  kms_key_id              = each.value.kms_key_id != null ? try(var.environment.kms_keys[each.value.kms_key_id].arn, each.value.kms_key_id) : null
+  kms_key_id              = each.value.kms_key_id
   recovery_window_in_days = each.value.recovery_window_in_days
 
   tags = merge(local.tags, {

--- a/main.tf
+++ b/main.tf
@@ -247,7 +247,7 @@ resource "aws_secretsmanager_secret" "placeholder" {
   #checkov:skip=CKV2_AWS_57: Ensure Secrets Manager secrets should have automatic rotation enabled
   for_each = var.secretsmanager_secrets
 
-  name                    = /${var.secretsmanager_secrets_prefix}${var.name}/${each.key}
+  name                    = "/${var.secretsmanager_secrets_prefix}${var.name}/${each.key}"
   description             = each.value.description
   kms_key_id              = each.value.kms_key_id != null ? try(var.environment.kms_keys[each.value.kms_key_id].arn, each.value.kms_key_id) : null
   recovery_window_in_days = each.value.recovery_window_in_days

--- a/main.tf
+++ b/main.tf
@@ -261,7 +261,6 @@ resource "aws_secretsmanager_secret_version" "fixed" {
   for_each = merge(
     local.secretsmanager_secrets_value,
     local.secretsmanager_secrets_random,
-    local.secretsmanager_secrets_file
   )
 
   secret_id     = aws_secretsmanager_secret.this[each.key]

--- a/main.tf
+++ b/main.tf
@@ -241,11 +241,28 @@ resource "random_password" "secrets" {
   special = each.value.special
 }
 
-resource "aws_secretsmanager_secret" "placeholder" {
-  # skipped check to keep consistent behaviour between ssm params and secrets
-  # Rotation can be added later as a configurable option. Some will want it, for some it will break things
+resource "aws_secretsmanager_secret" "fixed" {
+  # skipped check as the secret value is defined by terraform so cannot be rotated by AWS
   #checkov:skip=CKV2_AWS_57: Ensure Secrets Manager secrets should have automatic rotation enabled
-  for_each = var.secretsmanager_secrets
+  for_each = merge(
+    local.secretsmanager_secrets_value,
+    local.secretsmanager_secrets_random,
+  )
+
+  name                    = "/${var.secretsmanager_secrets_prefix}${var.name}/${each.key}"
+  description             = each.value.description
+  kms_key_id              = each.value.kms_key_id != null ? try(var.environment.kms_keys[each.value.kms_key_id].arn, each.value.kms_key_id) : null
+  recovery_window_in_days = each.value.recovery_window_in_days
+
+  tags = merge(local.tags, {
+    Name = "${var.name}-${each.key}"
+  })
+}
+
+resource "aws_secretsmanager_secret" "placeholder" {
+  # Rotation can be added later as a configurable option
+  #checkov:skip=CKV2_AWS_57: Ensure Secrets Manager secrets should have automatic rotation enabled
+  for_each = local.secretsmanager_secrets_default
 
   name                    = "/${var.secretsmanager_secrets_prefix}${var.name}/${each.key}"
   description             = each.value.description
@@ -263,14 +280,14 @@ resource "aws_secretsmanager_secret_version" "fixed" {
     local.secretsmanager_secrets_random,
   )
 
-  secret_id     = aws_secretsmanager_secret.this[each.key]
+  secret_id     = aws_secretsmanager_secret.fixed[each.key].id
   secret_string = each.value.value
 }
 
 resource "aws_secretsmanager_secret_version" "placeholder" {
   for_each = local.secretsmanager_secrets_default
 
-  secret_id     = aws_secretsmanager_secret.this[each.key].id
+  secret_id     = aws_secretsmanager_secret.placeholder[each.key].id
   secret_string = each.value.value
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -230,19 +230,53 @@ resource "aws_ssm_parameter" "placeholder" {
   }
 }
 
+#------------------------------------------------------------------------------
+# SecretManager Secrets
+#------------------------------------------------------------------------------
+
+resource "random_password" "secrets" {
+  for_each = local.secretsmanager_random_passwords
+
+  length  = each.value.length
+  special = each.value.special
+}
+
 resource "aws_secretsmanager_secret" "placeholder" {
   # skipped check to keep consistent behaviour between ssm params and secrets
   # Rotation can be added later as a configurable option. Some will want it, for some it will break things
   #checkov:skip=CKV2_AWS_57: Ensure Secrets Manager secrets should have automatic rotation enabled
   for_each = var.secretsmanager_secrets
 
-  name        = "/${var.secretsmanager_secrets_prefix}${var.name}/${each.key}"
-  description = each.value.description
-  kms_key_id  = each.value.kms_key_id
+  name                    = /${var.secretsmanager_secrets_prefix}${var.name}/${each.key}
+  description             = each.value.description
+  kms_key_id              = each.value.kms_key_id != null ? try(var.environment.kms_keys[each.value.kms_key_id].arn, each.value.kms_key_id) : null
+  recovery_window_in_days = each.value.recovery_window_in_days
 
   tags = merge(local.tags, {
     Name = "${var.name}-${each.key}"
   })
+}
+
+resource "aws_secretsmanager_secret_version" "fixed" {
+  for_each = merge(
+    local.secretsmanager_secrets_value,
+    local.secretsmanager_secrets_random,
+    local.secretsmanager_secrets_file
+  )
+
+  secret_id     = aws_secretsmanager_secret.this[each.key]
+  secret_string = each.value.value
+}
+
+resource "aws_secretsmanager_secret_version" "placeholder" {
+  for_each = local.secretsmanager_secrets_default
+
+  secret_id     = aws_secretsmanager_secret.this[each.key].id
+  secret_string = each.value.value
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
 }
 
 #------------------------------------------------------------------------------

--- a/main.tf
+++ b/main.tf
@@ -259,6 +259,16 @@ resource "aws_secretsmanager_secret" "fixed" {
   })
 }
 
+resource "aws_secretsmanager_secret_version" "fixed" {
+  for_each = merge(
+    local.secretsmanager_secrets_value,
+    local.secretsmanager_secrets_random,
+  )
+
+  secret_id     = aws_secretsmanager_secret.fixed[each.key].id
+  secret_string = each.value.value
+}
+
 resource "aws_secretsmanager_secret" "placeholder" {
   # Rotation can be added later as a configurable option
   #checkov:skip=CKV2_AWS_57: Ensure Secrets Manager secrets should have automatic rotation enabled
@@ -272,27 +282,6 @@ resource "aws_secretsmanager_secret" "placeholder" {
   tags = merge(local.tags, {
     Name = "${var.name}-${each.key}"
   })
-}
-
-resource "aws_secretsmanager_secret_version" "fixed" {
-  for_each = merge(
-    local.secretsmanager_secrets_value,
-    local.secretsmanager_secrets_random,
-  )
-
-  secret_id     = aws_secretsmanager_secret.fixed[each.key].id
-  secret_string = each.value.value
-}
-
-resource "aws_secretsmanager_secret_version" "placeholder" {
-  for_each = local.secretsmanager_secrets_default
-
-  secret_id     = aws_secretsmanager_secret.placeholder[each.key].id
-  secret_string = each.value.value
-
-  lifecycle {
-    ignore_changes = [secret_string]
-  }
 }
 
 #------------------------------------------------------------------------------

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -20,6 +20,8 @@ module "ec2_test_instance" {
   ebs_volume_config             = lookup(each.value, "ebs_volume_config", {})
   ebs_volumes                   = lookup(each.value, "ebs_volumes", {})
   ebs_volume_tags               = lookup(each.value, "ebs_volume_tags", {})
+  secretsmanager_secrets_prefix = lookup(each.value, "secretsmanager_secrets_prefix", "test/")
+  secretsmanager_secrets        = lookup(each.value, "secretsmanager_secrets", null)
   ssm_parameters_prefix         = lookup(each.value, "ssm_parameters_prefix", "test/")
   ssm_parameters                = lookup(each.value, "ssm_parameters", null)
   route53_records               = merge(local.ec2_test.route53_records, lookup(each.value, "route53_records", {}))

--- a/variables.tf
+++ b/variables.tf
@@ -197,10 +197,16 @@ variable "ssm_parameters" {
 }
 
 variable "secretsmanager_secrets" {
-  description = "A map of secretsmanager secrets to create. No value is created, add a value outside of terraform"
+  description = "A map of secretsmanager secrets to create. Set a specific value or a randomly generated value.  If neither random or value are set, a placeholder value is created which can be updated outside of terraform"
   type = map(object({
-    description = optional(string)
-    kms_key_id  = optional(string)
+    description             = optional(string)
+    kms_key_id              = optional(string)
+    recovery_window_in_days = optional(number)
+    random = optional(object({
+      length  = number
+      special = optional(bool)
+    }))
+    value = optional(string)
   }))
   default = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -208,7 +208,7 @@ variable "secretsmanager_secrets" {
     }))
     value = optional(string)
   }))
-  default = {}
+  default = null
 }
 
 variable "cloudwatch_metric_alarms" {


### PR DESCRIPTION
Add additional option to create SecretsManager secrets with fixed or random value, and allow recovery_window_in_days to be set. This brings it in line with equivalent SSM parameter option.
Tested in nomis.