### PR TITLE
DSOS-2423: ssm and secrets policy fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -307,7 +307,7 @@ data "aws_iam_policy_document" "ssm_params_and_secrets" {
     }
   }
   dynamic "statement" {
-    for_each = var.ssm_parameters != null ? ["secret"] : []
+    for_each = var.secretsmanager_secrets != null ? ["secret"] : []
     block {
       effect = "Allow"
       actions = flatten([

--- a/main.tf
+++ b/main.tf
@@ -294,19 +294,18 @@ resource "aws_secretsmanager_secret" "placeholder" {
 
 data "aws_iam_policy_document" "ssm_params_and_secrets" {
   count = var.ssm_parameters != null || var.secretsmanager_secrets != null ? 1 : 0
-  #dynamic "statement" {
-  #  # for_each = var.ssm_parameters != null ? ["ssm"] : []
-  #  for_each = []
-  #  block {
-  #    effect = "Allow"
-  #    actions = flatten([
-  #      "ssm:GetParameter",
-  #      length(aws_ssm_parameter.placeholder) != 0 ? ["ssm:PutParameter"] : []
-  #    ])
-  #    #tfsec:ignore:aws-iam-no-policy-wildcards: acccess scoped to parameter path of EC2
-  #    resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.id}:parameter/${var.ssm_parameters_prefix}${var.name}/*"]
-  #  }
-  #}
+  dynamic "statement" {
+    for_each = var.ssm_parameters != null ? ["ssm"] : []
+    block {
+      effect = "Allow"
+      actions = flatten([
+        "ssm:GetParameter",
+        length(aws_ssm_parameter.placeholder) != 0 ? ["ssm:PutParameter"] : []
+      ])
+      #tfsec:ignore:aws-iam-no-policy-wildcards: acccess scoped to parameter path of EC2
+      resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.id}:parameter/${var.ssm_parameters_prefix}${var.name}/*"]
+    }
+  }
   dynamic "statement" {
     for_each = var.secretsmanager_secrets != null ? ["secret"] : []
     block {

--- a/main.tf
+++ b/main.tf
@@ -306,7 +306,7 @@ data "aws_iam_policy_document" "ssm_params_and_secrets" {
     effect = "Allow"
     actions = flatten([
       "secretsmanager:GetSecretValue",
-      "secretsmanager:PutSecretValue"
+      length(aws_secretsmanager_secret.placeholder) != 0 ? ["secretsmanager:PutSecretValue"] : []
     ])
     #tfsec:ignore:aws-iam-no-policy-wildcards: acccess scoped to parameter path of EC2
     resources = ["arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.id}:secret:/${var.secretsmanager_secrets_prefix}${var.name}/*"]

--- a/main.tf
+++ b/main.tf
@@ -351,10 +351,10 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy" "ssm_params_and_secrets" {
-  count  = var.ssm_parameters != null || var.secretsmanager_secrets != null ? 1 : 0
+  count  = length(data.aws_iam_policy_document.ssm_params_and_secrets)
   name   = "Ec2SSMParamsAndSecretsPolicy-${var.name}"
   role   = aws_iam_role.this.id
-  policy = data.aws_iam_policy_document.ssm_params_and_secrets[0].json
+  policy = data.aws_iam_policy_document.ssm_params_and_secrets[count.index].json
 }
 
 resource "aws_iam_instance_profile" "this" {

--- a/main.tf
+++ b/main.tf
@@ -295,7 +295,8 @@ resource "aws_secretsmanager_secret" "placeholder" {
 data "aws_iam_policy_document" "ssm_params_and_secrets" {
   count = var.ssm_parameters != null || var.secretsmanager_secrets != null ? 1 : 0
   dynamic "statement" {
-    for_each = var.ssm_parameters != null ? ["ssm"] : []
+    # for_each = var.ssm_parameters != null ? ["ssm"] : []
+    for_each = []
     block {
       effect = "Allow"
       actions = flatten([

--- a/main.tf
+++ b/main.tf
@@ -344,7 +344,7 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy" "ssm_params_and_secrets" {
-  count  = var.ssm_parameters != null && var.secretsmanager_secrets != null ? 1 : 0
+  count  = var.ssm_parameters != null || var.secretsmanager_secrets != null ? 1 : 0
   name   = "Ec2SSMParamsAndSecretsPolicy-${var.name}"
   role   = aws_iam_role.this.id
   policy = data.aws_iam_policy_document.ssm_params_and_secrets.json

--- a/main.tf
+++ b/main.tf
@@ -293,23 +293,30 @@ resource "aws_secretsmanager_secret" "placeholder" {
 #------------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "ssm_params_and_secrets" {
-  statement {
-    effect = "Allow"
-    actions = flatten([
-      "ssm:GetParameter",
-      length(aws_ssm_parameter.placeholder) != 0 ? ["ssm:PutParameter"] : []
-    ])
-    #tfsec:ignore:aws-iam-no-policy-wildcards: acccess scoped to parameter path of EC2
-    resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.id}:parameter/${var.ssm_parameters_prefix}${var.name}/*"]
+  count = var.ssm_parameters != null || var.secretsmanager_secrets != null ? 1 : 0
+  dynamic "statement" {
+    for_each = var.ssm_parameters != null ? ["ssm"] : []
+    block {
+      effect = "Allow"
+      actions = flatten([
+        "ssm:GetParameter",
+        length(aws_ssm_parameter.placeholder) != 0 ? ["ssm:PutParameter"] : []
+      ])
+      #tfsec:ignore:aws-iam-no-policy-wildcards: acccess scoped to parameter path of EC2
+      resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.id}:parameter/${var.ssm_parameters_prefix}${var.name}/*"]
+    }
   }
-  statement {
-    effect = "Allow"
-    actions = flatten([
-      "secretsmanager:GetSecretValue",
-      length(aws_secretsmanager_secret.placeholder) != 0 ? ["secretsmanager:PutSecretValue"] : []
-    ])
-    #tfsec:ignore:aws-iam-no-policy-wildcards: acccess scoped to parameter path of EC2
-    resources = ["arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.id}:secret:/${var.secretsmanager_secrets_prefix}${var.name}/*"]
+  dynamic "statement" {
+    for_each = var.ssm_parameters != null ? ["secret"] : []
+    block {
+      effect = "Allow"
+      actions = flatten([
+        "secretsmanager:GetSecretValue",
+        length(aws_secretsmanager_secret.placeholder) != 0 ? ["secretsmanager:PutSecretValue"] : []
+      ])
+      #tfsec:ignore:aws-iam-no-policy-wildcards: acccess scoped to parameter path of EC2
+      resources = ["arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.id}:secret:/${var.secretsmanager_secrets_prefix}${var.name}/*"]
+    }
   }
 }
 
@@ -347,7 +354,7 @@ resource "aws_iam_role_policy" "ssm_params_and_secrets" {
   count  = var.ssm_parameters != null || var.secretsmanager_secrets != null ? 1 : 0
   name   = "Ec2SSMParamsAndSecretsPolicy-${var.name}"
   role   = aws_iam_role.this.id
-  policy = data.aws_iam_policy_document.ssm_params_and_secrets.json
+  policy = data.aws_iam_policy_document.ssm_params_and_secrets[0].json
 }
 
 resource "aws_iam_instance_profile" "this" {

--- a/main.tf
+++ b/main.tf
@@ -294,19 +294,19 @@ resource "aws_secretsmanager_secret" "placeholder" {
 
 data "aws_iam_policy_document" "ssm_params_and_secrets" {
   count = var.ssm_parameters != null || var.secretsmanager_secrets != null ? 1 : 0
-  dynamic "statement" {
-    # for_each = var.ssm_parameters != null ? ["ssm"] : []
-    for_each = []
-    block {
-      effect = "Allow"
-      actions = flatten([
-        "ssm:GetParameter",
-        length(aws_ssm_parameter.placeholder) != 0 ? ["ssm:PutParameter"] : []
-      ])
-      #tfsec:ignore:aws-iam-no-policy-wildcards: acccess scoped to parameter path of EC2
-      resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.id}:parameter/${var.ssm_parameters_prefix}${var.name}/*"]
-    }
-  }
+  #dynamic "statement" {
+  #  # for_each = var.ssm_parameters != null ? ["ssm"] : []
+  #  for_each = []
+  #  block {
+  #    effect = "Allow"
+  #    actions = flatten([
+  #      "ssm:GetParameter",
+  #      length(aws_ssm_parameter.placeholder) != 0 ? ["ssm:PutParameter"] : []
+  #    ])
+  #    #tfsec:ignore:aws-iam-no-policy-wildcards: acccess scoped to parameter path of EC2
+  #    resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.id}:parameter/${var.ssm_parameters_prefix}${var.name}/*"]
+  #  }
+  #}
   dynamic "statement" {
     for_each = var.secretsmanager_secrets != null ? ["secret"] : []
     block {

--- a/main.tf
+++ b/main.tf
@@ -296,7 +296,7 @@ data "aws_iam_policy_document" "ssm_params_and_secrets" {
   count = var.ssm_parameters != null || var.secretsmanager_secrets != null ? 1 : 0
   dynamic "statement" {
     for_each = var.ssm_parameters != null ? ["ssm"] : []
-    block {
+    content {
       effect = "Allow"
       actions = flatten([
         "ssm:GetParameter",
@@ -308,7 +308,7 @@ data "aws_iam_policy_document" "ssm_params_and_secrets" {
   }
   dynamic "statement" {
     for_each = var.secretsmanager_secrets != null ? ["secret"] : []
-    block {
+    content {
       effect = "Allow"
       actions = flatten([
         "secretsmanager:GetSecretValue",


### PR DESCRIPTION
Fix to the SSM parameter and secrets policy.  
Bug fix: changed "and" condition to "or". Ensures policy created if either SSM Params or Secrets created. 
Best practice: add minimum possible permissions (e.g. only need Put if there are placeholder params/secrets)