### PR TITLE
Adds a reference to a second deployed example for using the ec2 module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ module "ec2_test_instance" {
 }
 
 ```
-For a deployed example, please check [example](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/example/ec2.tf#L233)
+For a deployed example, please check [example](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/example/ec2.tf#L233). A second [fully self-contained example](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/example/ec2_complete.tf) has been added for ease of use.
 
 ### Setting backup tags
 Read [the Modernisation Platform backup functionality](https://user-guide.modernisation-platform.service.justice.gov.uk/concepts/environments/backups.html#backups) to understand how the backup plan works.


### PR DESCRIPTION
This PR adds a reference in the module's README to a second deployed example. This second example is fully self-contained and easier to use. It will not necessitate a new release.