### PR TITLE
Redaction of sensitive data items from workflow log output.

### DIFF
--- a/.github/workflows/go-terratest.yml
+++ b/.github/workflows/go-terratest.yml
@@ -27,4 +27,6 @@ jobs:
         run: go mod download
       - name: Run Go Tests
         working-directory: test
-        run: go test -v
+        run: |
+          chmod 700 ../scripts/redact-output.sh
+          go test -v | ../scripts/redact-output.sh

--- a/scripts/redact-output.sh
+++ b/scripts/redact-output.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Based on: https://github.com/ministryofjustice/opg-org-infra/blob/main/scripts/redact_output.sh
+
+sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+    -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+    -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+    -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+    -e 's/\[id=.*\]/\[id=<REDACTED>\]/g' \
+    -e 's/::[0-9]\{12\}:/::REDACTED:/g' \
+    -e 's/:[0-9]\{12\}:/:REDACTED:/g'


### PR DESCRIPTION
This amends the terratest workflow to redact account_numbers and other data items from the terraform plan output in the test workflow.

The use of this script to redact output from the go test has been successfully tested locally.