### PR TITLE
Removes tee as it was splitting the output causing un-redacted values.

### DIFF
--- a/.github/workflows/go-terratest.yml
+++ b/.github/workflows/go-terratest.yml
@@ -29,5 +29,5 @@ jobs:
         working-directory: test
         run: |
           chmod 700 ../scripts/redact-output.sh
-          go test -v | tee >(../scripts/redact-output.sh)
+          go test -v | ../scripts/redact-output.sh
           exit ${PIPESTATUS[0]}


### PR DESCRIPTION
Fixes an issue whereby tee was splitting the log output leading to un-redacted values.