### PR TITLE
feature 7412 - added AmazonSSMManagedInstanceCore policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -340,7 +340,7 @@ resource "aws_iam_role" "this" {
     }
   )
 
-  managed_policy_arns = var.instance_profile_policies
+    managed_policy_arns = concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies)
 
   tags = merge(
     local.tags,


### PR DESCRIPTION
## A reference to the issue / Description of it

[#7412](https://github.com/ministryofjustice/modernisation-platform/issues/7412)

## How does this PR fix the problem?

PR adds the SSM policy as a default when an instance is created through the module

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

tested by calling the module with instances that both have the policy already and, and instances that do not have the policy and the changed did not break.

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

No

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
