### PR TITLE
Tm/tm 745/remove deprecated managed policy arn ref

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -346,13 +346,11 @@ resource "aws_iam_role" "this" {
   )
 }
 
-# Remove individual policy attachments and replace with exclusive management
-resource "aws_iam_role_policy_attachments_exclusive" "this" {
-  role_name = aws_iam_role.this.name
-  policy_arns = concat(
-    ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"],
-    var.instance_profile_policies
-  )
+# IAM role policy attachment
+resource "aws_iam_role_policy_attachment" "this" {
+  count      = length(concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies))
+  role       = aws_iam_role.this.name
+  policy_arn = element(concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies), count.index)
 }
 
 resource "aws_iam_role_policy" "ssm_params_and_secrets" {

--- a/main.tf
+++ b/main.tf
@@ -340,14 +340,26 @@ resource "aws_iam_role" "this" {
     }
   )
 
-  managed_policy_arns = concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies)
-
   tags = merge(
     local.tags,
     {
       Name = "${var.iam_resource_names_prefix}-role-${var.name}"
     },
   )
+}
+
+# Attach SSM core policy
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# Attach additional policies from variable
+resource "aws_iam_role_policy_attachment" "additional" {
+  count = length(var.instance_profile_policies)
+
+  role       = aws_iam_role.this.name
+  policy_arn = var.instance_profile_policies[count.index]
 }
 
 resource "aws_iam_role_policy" "ssm_params_and_secrets" {


### PR DESCRIPTION
We get persistent warnings that `managed_policy_arn` is deprecated. 

Replace this with resource [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) in response to deployment warnings: 

```
│ Warning: Argument is deprecated
│ 
│   with module.baseline.module.ec2_instance["t1-ncr-db-1-a"].aws_iam_role.this,
│   on .terraform/modules/baseline.ec2_instance/main.tf line 343, in resource "aws_iam_role" "this":
│  343:   managed_policy_arns = var.instance_profile_policies
│ 
│ The managed_policy_arns argument is deprecated. Use the
│ aws_iam_role_policy_attachment resource instead. If Terraform should
│ exclusively manage all managed policy attachments (the current behavior of
│ this argument), use the aws_iam_role_policy_attachments_exclusive resource
│ as well.
```