### PR TITLE
updates to add in a skip of the ssm policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -348,9 +348,9 @@ resource "aws_iam_role" "this" {
 
 # IAM role policy attachment
 resource "aws_iam_role_policy_attachment" "this" {
-  count      = length(concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies))
+  count      = var.skip_ssm_iam_role_policy_attachment ? length(var.instance_profile_policies) : length(concat([var.default_ssm_policy_arn], var.instance_profile_policies))
   role       = aws_iam_role.this.name
-  policy_arn = element(concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies), count.index)
+  policy_arn = var.skip_ssm_iam_role_policy_attachment ? element(var.instance_profile_policies, count.index) : element(concat([var.default_ssm_policy_arn], var.instance_profile_policies), count.index)
 }
 
 resource "aws_iam_role_policy" "ssm_params_and_secrets" {

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -13,18 +13,19 @@ module "ec2_test_instance" {
 
   name = "${each.key}${random_id.test_id.hex}"
 
-  ami_name                      = each.value.ami_name
-  ami_owner                     = try(each.value.ami_owner, "core-shared-services-production")
-  instance                      = merge(local.ec2_test.instance, lookup(each.value, "instance", {}))
-  ebs_volumes_copy_all_from_ami = try(each.value.ebs_volumes_copy_all_from_ami, true)
-  ebs_volume_config             = lookup(each.value, "ebs_volume_config", {})
-  ebs_volumes                   = lookup(each.value, "ebs_volumes", {})
-  ebs_volume_tags               = lookup(each.value, "ebs_volume_tags", {})
-  secretsmanager_secrets_prefix = lookup(each.value, "secretsmanager_secrets_prefix", "test/")
-  secretsmanager_secrets        = lookup(each.value, "secretsmanager_secrets", null)
-  ssm_parameters_prefix         = lookup(each.value, "ssm_parameters_prefix", "test/")
-  ssm_parameters                = lookup(each.value, "ssm_parameters", null)
-  route53_records               = merge(local.ec2_test.route53_records, lookup(each.value, "route53_records", {}))
+  ami_name                            = each.value.ami_name
+  ami_owner                           = try(each.value.ami_owner, "core-shared-services-production")
+  instance                            = merge(local.ec2_test.instance, lookup(each.value, "instance", {}))
+  ebs_volumes_copy_all_from_ami       = try(each.value.ebs_volumes_copy_all_from_ami, true)
+  ebs_volume_config                   = lookup(each.value, "ebs_volume_config", {})
+  ebs_volumes                         = lookup(each.value, "ebs_volumes", {})
+  ebs_volume_tags                     = lookup(each.value, "ebs_volume_tags", {})
+  secretsmanager_secrets_prefix       = lookup(each.value, "secretsmanager_secrets_prefix", "test/")
+  secretsmanager_secrets              = lookup(each.value, "secretsmanager_secrets", null)
+  skip_ssm_iam_role_policy_attachment = true
+  ssm_parameters_prefix               = lookup(each.value, "ssm_parameters_prefix", "test/")
+  ssm_parameters                      = lookup(each.value, "ssm_parameters", null)
+  route53_records                     = merge(local.ec2_test.route53_records, lookup(each.value, "route53_records", {}))
 
   iam_resource_names_prefix = "ec2-test-instance${random_id.test_id.hex}"
   instance_profile_policies = local.ec2_common_managed_policies

--- a/variables.tf
+++ b/variables.tf
@@ -144,7 +144,17 @@ variable "ebs_volumes" {
     kms_key_id  = optional(string)
   }))
 }
+variable "skip_ssm_iam_role_policy_attachment" {
+  description = "If true, skip the IAM role policy attachment"
+  type        = bool
+  default     = false
+}
 
+variable "default_ssm_policy_arn" {
+  description = "Default SSM policy ARN to attach"
+  type        = string
+  default     = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
 variable "ebs_volume_tags" {
   description = "Additional tags to apply to ebs volumes"
   type        = map(string)


### PR DESCRIPTION
Adding the ability to skip adding the ssm policy to ec2 instance as part of Re-visit how we apply the AmazonSSMManagedInstanceCore in the ec2-instance and ec2-autoscaling-group modules
[#8969](https://github.com/ministryofjustice/modernisation-platform/issues/8969)