### PR TITLE
Feat/skip ssm policy attachment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -348,9 +348,9 @@ resource "aws_iam_role" "this" {
 
 # IAM role policy attachment
 resource "aws_iam_role_policy_attachment" "this" {
-  count      = length(concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies))
+  count      = var.skip_iam_role_policy_attachment ? length(var.instance_profile_policies) : length(concat([var.default_policy_arn], var.instance_profile_policies))
   role       = aws_iam_role.this.name
-  policy_arn = element(concat(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies), count.index)
+  policy_arn = var.skip_iam_role_policy_attachment ? element(var.instance_profile_policies, count.index) : element(concat([var.default_policy_arn], var.instance_profile_policies), count.index)
 }
 
 resource "aws_iam_role_policy" "ssm_params_and_secrets" {

--- a/main.tf
+++ b/main.tf
@@ -348,7 +348,7 @@ resource "aws_iam_role" "this" {
 
 # IAM role policy attachment
 resource "aws_iam_role_policy_attachment" "this" {
-  for_each   = toset(concat(var.skip_iam_role_policy_attachment ? [] : ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies))
+  for_each   = toset(concat([var.default_policy_arn], coalesce(var.instance_profile_policies, [])))
   role       = aws_iam_role.this.name
   policy_arn = each.key
 }

--- a/main.tf
+++ b/main.tf
@@ -348,9 +348,9 @@ resource "aws_iam_role" "this" {
 
 # IAM role policy attachment
 resource "aws_iam_role_policy_attachment" "this" {
-  count      = var.skip_iam_role_policy_attachment ? length(var.instance_profile_policies) : length(concat([var.default_policy_arn], var.instance_profile_policies))
+  for_each   = toset(concat(var.skip_iam_role_policy_attachment ? [] : ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.instance_profile_policies))
   role       = aws_iam_role.this.name
-  policy_arn = var.skip_iam_role_policy_attachment ? element(var.instance_profile_policies, count.index) : element(concat([var.default_policy_arn], var.instance_profile_policies), count.index)
+  policy_arn = each.key
 }
 
 resource "aws_iam_role_policy" "ssm_params_and_secrets" {

--- a/test/unit-test/locals.tf
+++ b/test/unit-test/locals.tf
@@ -94,6 +94,7 @@ locals {
         }
         ami_name  = "RHEL-7.9_HVM-*"
         ami_owner = "309956199498"
+        instance_profile_policies = []
       }
       example-test-instance-2 = {
         tags = {

--- a/test/unit-test/locals.tf
+++ b/test/unit-test/locals.tf
@@ -92,8 +92,8 @@ locals {
         ebs_volume_tags = {
           backup = false
         }
-        ami_name  = "RHEL-7.9_HVM-*"
-        ami_owner = "309956199498"
+        ami_name                  = "RHEL-7.9_HVM-*"
+        ami_owner                 = "309956199498"
         instance_profile_policies = []
       }
       example-test-instance-2 = {
@@ -163,4 +163,3 @@ resource "aws_key_pair" "ec2-terratest-user" {
     },
   )
 }
-

--- a/test/unit-test/locals.tf
+++ b/test/unit-test/locals.tf
@@ -3,7 +3,7 @@ locals {
 
   # create list of common managed policies that can be attached to ec2 instance profiles
   ec2_common_managed_policies = [
-    aws_iam_policy.ec2_test_common_policy.arn
+    aws_iam_policy.ec2_test_common_policy.arn,
   ]
 
   tags = {

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -24,7 +24,6 @@ module "ec2_test_instance" {
   secretsmanager_secrets          = lookup(each.value, "secretsmanager_secrets", null)
   ssm_parameters_prefix           = lookup(each.value, "ssm_parameters_prefix", "test/")
   ssm_parameters                  = lookup(each.value, "ssm_parameters", null)
-  skip_iam_role_policy_attachment = false
   route53_records                 = merge(local.ec2_test.route53_records, lookup(each.value, "route53_records", {}))
 
   iam_resource_names_prefix = "ec2-test-instance${random_id.test_id.hex}"

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -13,18 +13,18 @@ module "ec2_test_instance" {
 
   name = "${each.key}${random_id.test_id.hex}"
 
-  ami_name                        = each.value.ami_name
-  ami_owner                       = try(each.value.ami_owner, "core-shared-services-production")
-  instance                        = merge(local.ec2_test.instance, lookup(each.value, "instance", {}))
-  ebs_volumes_copy_all_from_ami   = try(each.value.ebs_volumes_copy_all_from_ami, true)
-  ebs_volume_config               = lookup(each.value, "ebs_volume_config", {})
-  ebs_volumes                     = lookup(each.value, "ebs_volumes", {})
-  ebs_volume_tags                 = lookup(each.value, "ebs_volume_tags", {})
-  secretsmanager_secrets_prefix   = lookup(each.value, "secretsmanager_secrets_prefix", "test/")
-  secretsmanager_secrets          = lookup(each.value, "secretsmanager_secrets", null)
-  ssm_parameters_prefix           = lookup(each.value, "ssm_parameters_prefix", "test/")
-  ssm_parameters                  = lookup(each.value, "ssm_parameters", null)
-  route53_records                 = merge(local.ec2_test.route53_records, lookup(each.value, "route53_records", {}))
+  ami_name                      = each.value.ami_name
+  ami_owner                     = try(each.value.ami_owner, "core-shared-services-production")
+  instance                      = merge(local.ec2_test.instance, lookup(each.value, "instance", {}))
+  ebs_volumes_copy_all_from_ami = try(each.value.ebs_volumes_copy_all_from_ami, true)
+  ebs_volume_config             = lookup(each.value, "ebs_volume_config", {})
+  ebs_volumes                   = lookup(each.value, "ebs_volumes", {})
+  ebs_volume_tags               = lookup(each.value, "ebs_volume_tags", {})
+  secretsmanager_secrets_prefix = lookup(each.value, "secretsmanager_secrets_prefix", "test/")
+  secretsmanager_secrets        = lookup(each.value, "secretsmanager_secrets", null)
+  ssm_parameters_prefix         = lookup(each.value, "ssm_parameters_prefix", "test/")
+  ssm_parameters                = lookup(each.value, "ssm_parameters", null)
+  route53_records               = merge(local.ec2_test.route53_records, lookup(each.value, "route53_records", {}))
 
   iam_resource_names_prefix = "ec2-test-instance${random_id.test_id.hex}"
   instance_profile_policies = local.ec2_common_managed_policies

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -13,18 +13,19 @@ module "ec2_test_instance" {
 
   name = "${each.key}${random_id.test_id.hex}"
 
-  ami_name                      = each.value.ami_name
-  ami_owner                     = try(each.value.ami_owner, "core-shared-services-production")
-  instance                      = merge(local.ec2_test.instance, lookup(each.value, "instance", {}))
-  ebs_volumes_copy_all_from_ami = try(each.value.ebs_volumes_copy_all_from_ami, true)
-  ebs_volume_config             = lookup(each.value, "ebs_volume_config", {})
-  ebs_volumes                   = lookup(each.value, "ebs_volumes", {})
-  ebs_volume_tags               = lookup(each.value, "ebs_volume_tags", {})
-  secretsmanager_secrets_prefix = lookup(each.value, "secretsmanager_secrets_prefix", "test/")
-  secretsmanager_secrets        = lookup(each.value, "secretsmanager_secrets", null)
-  ssm_parameters_prefix         = lookup(each.value, "ssm_parameters_prefix", "test/")
-  ssm_parameters                = lookup(each.value, "ssm_parameters", null)
-  route53_records               = merge(local.ec2_test.route53_records, lookup(each.value, "route53_records", {}))
+  ami_name                        = each.value.ami_name
+  ami_owner                       = try(each.value.ami_owner, "core-shared-services-production")
+  instance                        = merge(local.ec2_test.instance, lookup(each.value, "instance", {}))
+  ebs_volumes_copy_all_from_ami   = try(each.value.ebs_volumes_copy_all_from_ami, true)
+  ebs_volume_config               = lookup(each.value, "ebs_volume_config", {})
+  ebs_volumes                     = lookup(each.value, "ebs_volumes", {})
+  ebs_volume_tags                 = lookup(each.value, "ebs_volume_tags", {})
+  secretsmanager_secrets_prefix   = lookup(each.value, "secretsmanager_secrets_prefix", "test/")
+  secretsmanager_secrets          = lookup(each.value, "secretsmanager_secrets", null)
+  ssm_parameters_prefix           = lookup(each.value, "ssm_parameters_prefix", "test/")
+  ssm_parameters                  = lookup(each.value, "ssm_parameters", null)
+  skip_iam_role_policy_attachment = false
+  route53_records                 = merge(local.ec2_test.route53_records, lookup(each.value, "route53_records", {}))
 
   iam_resource_names_prefix = "ec2-test-instance${random_id.test_id.hex}"
   instance_profile_policies = local.ec2_common_managed_policies

--- a/variables.tf
+++ b/variables.tf
@@ -231,3 +231,15 @@ variable "cloudwatch_metric_alarms" {
   }))
   default = {}
 }
+
+variable "skip_iam_role_policy_attachment" {
+  description = "If true, skip the IAM role policy attachment"
+  type        = bool
+  default     = false
+}
+
+variable "default_policy_arn" {
+  description = "Default policy ARN to attach"
+  type        = string
+  default     = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -232,12 +232,6 @@ variable "cloudwatch_metric_alarms" {
   default = {}
 }
 
-variable "skip_iam_role_policy_attachment" {
-  description = "If true, skip the IAM role policy attachment"
-  type        = bool
-  default     = false
-}
-
 variable "default_policy_arn" {
   description = "Default policy ARN to attach"
   type        = string


### PR DESCRIPTION
- change resource to use toset (ensures only one instance of each rule)
- will concat var.default_policy_arn with users value of var.instance_profile_policies
- if var.instance_profile_policies = null/empty then coalesce(var.instance_profile_policies, []) returns an empty list

So you in any case aws_iam_role_policy_attachment will be var.default_policy_arn OR var.instance_profile_policies and it will only ever contain one reference to the default, whether it's duplicated in var.instance_profile_policies or not

This means adding another switch to the module variables to include it or not isn't needed and in modernisation-platform-environments repo all we need to do is change the module reference.