### PR TITLE
Fix: Resolve Terraform `for_each` issue in `aws_iam_role_policy_attachment`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -348,9 +348,13 @@ resource "aws_iam_role" "this" {
 
 # IAM role policy attachment
 resource "aws_iam_role_policy_attachment" "this" {
-  for_each   = toset(concat([var.default_policy_arn], coalesce(var.instance_profile_policies, [])))
+  for_each = {
+    for idx, policy_arn in concat([var.default_policy_arn], coalesce(var.instance_profile_policies, [])) :
+    idx => policy_arn
+  }
+
   role       = aws_iam_role.this.name
-  policy_arn = each.key
+  policy_arn = each.value
 }
 
 resource "aws_iam_role_policy" "ssm_params_and_secrets" {


### PR DESCRIPTION
**What**:
Fixes Terraform errors related to `for_each` usage in `aws_iam_role_policy_attachment` resource by converting the list of policies into a map with static keys.

**Why**:
Terraform requires static keys for `for_each` so it can track resource instances during planning. Previously, using a list/set with potentially unknown values caused plan failures in some cases, including during unit-test runs.

**How**:
- Updated `for_each` expression to produce a map with keys as indexes (`idx`) and values as policy ARNs.
- Ensured variables `default_policy_arn` and `instance_profile_policies` have appropriate default values.

Testing:
- Ran Terratest unit-tests - all tests now pass without errors.