### PR TITLE
add checkov skip for test security group

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -41,11 +41,11 @@ misconfigurations:
   - id: AVD-AWS-0057
   - id: AVD-AWS-0104
     paths:
-      - "./test/unit-test/security-groups.tf"
+      - "security-groups.tf"
     statement: Accept the risk - Test SG
   - id: AVD-AWS-0107
     paths:
-      - "./test/unit-test/security-groups.tf"
+      - "security-groups.tf"
     statement: Accept the risk - Test SG
 
 secrets:

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -41,12 +41,12 @@ misconfigurations:
   - id: AVD-AWS-0057
   - id: AVD-AWS-0104
     paths:
-      - "test/unit-test/security-groups.tf"
-    statement: Security group for testing only, not for production use
+      - test/unit-test/security-groups.tf
+    statement: Accept the risk - Test SG
   - id: AVD-AWS-0107
     paths:
-      - "test/unit-test/security-groups.tf"
-    statement: Security group for testing only, not for production use
+      - test/unit-test/security-groups.tf
+    statement: Accept the risk - Test SG
 
 secrets:
 

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -41,11 +41,11 @@ misconfigurations:
   - id: AVD-AWS-0057
   - id: AVD-AWS-0104
     paths:
-      - test/unit-test/security-groups.tf
+      - "test/unit-test/security-groups.tf"
     statement: Accept the risk - Test SG
   - id: AVD-AWS-0107
     paths:
-      - test/unit-test/security-groups.tf
+      - "test/unit-test/security-groups.tf"
     statement: Accept the risk - Test SG
 
 secrets:

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -39,6 +39,14 @@ misconfigurations:
   - id: AVD-AWS-0031
   - id: AVD-AWS-0039
   - id: AVD-AWS-0057
+  - id: AVD-AWS-0104
+    paths:
+      - "test/unit-test/security-groups.tf"
+    statement: Security group for testing only, not for production use
+  - id: AVD-AWS-0107
+    paths:
+      - "test/unit-test/security-groups.tf"
+    statement: Security group for testing only, not for production use
 
 secrets:
 

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -39,14 +39,6 @@ misconfigurations:
   - id: AVD-AWS-0031
   - id: AVD-AWS-0039
   - id: AVD-AWS-0057
-  - id: AVD-AWS-0104
-    paths:
-      - "security-groups.tf"
-    statement: Accept the risk - Test SG
-  - id: AVD-AWS-0107
-    paths:
-      - "security-groups.tf"
-    statement: Accept the risk - Test SG
 
 secrets:
 

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -41,11 +41,11 @@ misconfigurations:
   - id: AVD-AWS-0057
   - id: AVD-AWS-0104
     paths:
-      - "test/unit-test/security-groups.tf"
+      - "./test/unit-test/security-groups.tf"
     statement: Accept the risk - Test SG
   - id: AVD-AWS-0107
     paths:
-      - "test/unit-test/security-groups.tf"
+      - "./test/unit-test/security-groups.tf"
     statement: Accept the risk - Test SG
 
 secrets:

--- a/test/unit-test/security-groups.tf
+++ b/test/unit-test/security-groups.tf
@@ -8,19 +8,19 @@ resource "aws_security_group" "test" {
   description = "Test SG for Terratest"
   vpc_id      = data.aws_vpc.shared.id
   ingress {
-    from_port        = 0
-    to_port          = 6000
-    protocol         = "tcp"
-    cidr_blocks      = ["10.26.0.0/21"]
-    description      = "Test SG for Terratest"
+    from_port   = 0
+    to_port     = 6000
+    protocol    = "tcp"
+    cidr_blocks = ["10.26.0.0/21"]
+    description = "Test SG for Terratest"
   }
 
   egress {
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["10.26.0.0/21"]
-    description      = "Test SG for Terratest"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["10.26.0.0/21"]
+    description = "Test SG for Terratest"
 
   }
 

--- a/test/unit-test/security-groups.tf
+++ b/test/unit-test/security-groups.tf
@@ -11,8 +11,7 @@ resource "aws_security_group" "test" {
     from_port        = 0
     to_port          = 6000
     protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
+    cidr_blocks      = ["10.26.0.0/21"]
     description      = "Test SG for Terratest"
   }
 
@@ -20,8 +19,7 @@ resource "aws_security_group" "test" {
     from_port        = 0
     to_port          = 0
     protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
+    cidr_blocks      = ["10.26.0.0/21"]
     description      = "Test SG for Terratest"
 
   }

--- a/test/unit-test/security-groups.tf
+++ b/test/unit-test/security-groups.tf
@@ -3,6 +3,7 @@ resource "aws_security_group" "test" {
   #checkov:skip=CKV_AWS_25:
   #checkov:skip=CKV_AWS_24:
   #checkov:skip=CKV_AWS_260:
+  #checkov:skip=CKV_AWS_382:
   name        = "Terratest-SG${random_id.test_id.hex}"
   description = "Test SG for Terratest"
   vpc_id      = data.aws_vpc.shared.id

--- a/test/unit-test/versions.tf
+++ b/test/unit-test/versions.tf
@@ -4,6 +4,10 @@ terraform {
       version = "~> 5.0"
       source  = "hashicorp/aws"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7"
+    }
   }
   required_version = ">= 1.0.1"
 }


### PR DESCRIPTION
Checkov is currently reporting failure `CKV_AWS_382: "Ensure no security groups allow egress from 0.0.0.0:0 to port -1"` 

This PR adds a skip as the security group is only added temporarily as part of the Terratest checks and is then deleted. 
